### PR TITLE
[task/13]vm_do_claim_page 함수 구현

### DIFF
--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -158,6 +158,13 @@ bool vm_claim_page(void *va UNUSED) {
   return vm_do_claim_page(page);
 }
 
+void vm_free_frame(struct frame *frame) {
+  ASSERT(frame != NULL);
+  ASSERT(frame->page == NULL);
+  palloc_free_page(frame->kva);
+  free(frame);
+}
+
 /* Claim the PAGE and set up the mmu. */
 static bool vm_do_claim_page(struct page *page) {
   struct frame *frame = vm_get_frame();
@@ -167,8 +174,22 @@ static bool vm_do_claim_page(struct page *page) {
   page->frame = frame;
 
   /* TODO: Insert page table entry to map page's VA to frame's PA. */
+  struct thread *cur = thread_current();
+  if (!pml4_set_page(cur->pml4, page->va, frame->kva, page->writable)) {
+    frame->page = NULL;
+    page->frame = NULL;
+    vm_free_frame(frame);
+    return false;
+  }
 
-  return swap_in(page, frame->kva);
+  if (!swap_in(page, frame->kva)) {
+    pml4_clear_page(cur->pml4, page->va);
+    frame->page = NULL;
+    page->frame = NULL;
+    vm_free_frame(frame);
+    return false;
+  }
+  return true;
 }
 
 /* Initialize new supplemental page table */


### PR DESCRIPTION
## vm_do_claim_page

### vm_do_claim_page
#### pml4_set_page()
- pml4_set_page()를 사용하여 현재 스레드의 pml4에 가상주소 -> 물리주소 매핑을 추가
- page -> writable에 따라 읽기/쓰기 권한 설정
- 실패 시 링크를 끊고 프레임 반납 후 false 반환

#### swap_in(page, frame->kva)
- 페이지 타입에 맞춰 내용을 프레임에 적재
- 실패 시 pml4 매핑을 되돌리고 링크를 끊고 프레임 반납 후 false 반환
- 매핑을 되돌리기 위해 pml4_clear_page를 사용했습니다.

#### void vm_free_frame(struct frame *frame)
- 매핑 및 적재 실패 시 할당된 frame을 제거(반납)해주기 위해서 생성했습니다.


close: #13