### PR TITLE
9.25/task/물리프레임 할당/vm_get_page

### DIFF
--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -112,16 +112,29 @@ static struct frame *vm_evict_frame(void) {
   return NULL;
 }
 
-/* palloc() and get frame. If there is no available page, evict the page
- * and return it. This always return valid address. That is, if the user pool
- * memory is full, this function evicts the frame to get the available memory
- * space.*/
+/* palloc()으로 프레임(frame)을 획득한다. 사용 가능한 페이지가 없으면,
+ * 페이지를 축출(evict)하고 반환한다. 이 함수는 항상 유효한 주소를 반환한다.
+ * 즉, 사용자 풀(user pool) 메모리가 가득 찬 경우, 이 함수는 프레임을
+ * 축출하여 사용 가능한 메모리 공간을 확보한다. */
+
 static struct frame *vm_get_frame(void) {
   struct frame *frame = NULL;
   /* TODO: Fill this function. */
 
+  // 물리페이지 획득
+  void *kernal_va = palloc_get_page(PAL_USER);
+  if (kernal_va == NULL) {
+    PANIC("todo");  // 실패시
+  }
+
+  // 프레임구조체 생성 및 초기화
+  struct frame *frame = malloc(sizeof(struct frame));
+  frame->kva = kva;
+  frame->page = NULL;
+
   ASSERT(frame != NULL);
   ASSERT(frame->page == NULL);
+
   return frame;
 }
 


### PR DESCRIPTION
- 물리프레임을 palloc()을 사용해서 할당받음.
- git book에서는 사용가능한 페이지가 없다면 panic("todo").

### 함수 흐름 설명
1. palloc_get_page(PAL_USER) 물리 페이지 할당 시도
2. 성공시 paloc이 주소를 반환하고 실패시 palloc이 null을 반환
3. malloc을 호출하여 물리 페이지를 관리할 frame 구조체를 위한 메모리 할당을 함
4. 만약 malloc 실패시 이전 얻었던 물리 페이지를 palloc_free_page로 반납 하고 실패 알림
5. 모든 준비가 끝난 frame을 호출 한 곳으로 넘겨줌