### PR TITLE
[task/25] vm_alloc_page_with_initializer 구현

### DIFF
--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -67,13 +67,12 @@ bool vm_alloc_page_with_initializer(enum vm_type type, void *upage,
   if (spt_find_page(spt, upage) == NULL) {
     // upage가 이미 사용 중인지 확인한다.
 
-    struct page *page = malloc(sizeof(struct page));
+    struct page *page = calloc(1, sizeof(struct page));
     // 새로운 페이지 구조체를 동적으로 할당
     if (page == NULL) {
       goto err;
     }
 
-    page->writable = writable;
     page->frame = NULL;
 
     bool (*initializer)(struct page *, enum vm_type, void *);
@@ -94,6 +93,7 @@ bool vm_alloc_page_with_initializer(enum vm_type type, void *upage,
 
     uninit_new(page, upage, init, type, aux, initializer);
     // uninit_new 함수를 사용하여 페이지를 초기화한다.
+    page->writable = writable;
 
     if (!spt_insert_page(spt, page)) {
       // 페이지를 보조 페이지 테이블에 삽입한다.


### PR DESCRIPTION
## vm_alloc_page_with_initializer
### 요약
- 가상 주소 upage를 페이지 경계로 내린 후 SPT에 등록된 페이지인지 확인
- 비어 있다면 새로운 struct page를 생성하고 타입(VM_ANON/VM_FILE)에 맞는 initializer 선택
- uninit_new()를 통해 UNINIT 상태의 페이지를 생성하고 SPT에 삽입
- 성공 시 true, 실패 시 false

### 흐름
1. pg_round_down(upage)로 페이지 경계 맞춤
2. spt_find_page()로 이미 등록된 페이지 여부 확인
3. malloc으로 struct page 생성 및 기본 필드(writable, frame=NULL) 초기화
4. initializer 선택
    - VM_ANON -> anon_initializer
    - VM_FILE -> file_backed_initializer
5. uninit_new(page, upage, init, type, aux, initializer)로 UNINIT 페이지 등록
6. spt_insert_page() 호출하여 SPT 삽입
 
close: #25 
