### PR TITLE
10,01/task/uninit타입->anon타입 초기화

### DIFF
--- a/pintos/include/vm/anon.h
+++ b/pintos/include/vm/anon.h
@@ -5,9 +5,11 @@ struct page;
 enum vm_type;
 
 struct anon_page {
+  // 미할당 상태 : SIZE_MAX or 할당 상태 : 해당 슬롯 idx
+  size_t slot_idx SIZE_MAX;
 };
 
-void vm_anon_init (void);
-bool anon_initializer (struct page *page, enum vm_type type, void *kva);
+void vm_anon_init(void);
+bool anon_initializer(struct page *page, enum vm_type type, void *kva);
 
 #endif

--- a/pintos/vm/anon.c
+++ b/pintos/vm/anon.c
@@ -1,7 +1,9 @@
 /* anon.c: Implementation of page for non-disk image (a.k.a. anonymous page). */
+#include "devices/anon.h"
+
 #include "devices/disk.h"
-#include "include/threads/vaddr.h"
-#include "lib/kernel/bitmap.h"
+#include "include/vaddr.h"
+#include "lib/bitmap.h"
 #include "vm/vm.h"
 
 /* DO NOT MODIFY BELOW LINE */
@@ -37,14 +39,17 @@ void vm_anon_init(void) {
   if (swap_table == NULL) {
     return;
   }
+
+  return true;
 }
 
-/* 파일 매핑을 초기화 합니다. */
+/* anon_page를 초기화 합니다. */
 bool anon_initializer(struct page *page, enum vm_type type, void *kva) {
   /* 핸들러를 설정합니다. */
   page->operations = &anon_ops;
+  page->anon.slot_idx = SIZE_MAX;
 
-  struct anon_page *anon_page = &page->anon;
+  return true;
 }
 
 /* Swap in the page by read contents from the swap disk. */


### PR DESCRIPTION
### 호출 시점
- uninit_initializer함수가 기존의 uninit타입에서 anon타입으로의 타입변환을 위해 호출

### 구조체내 필드 추가
- anon.h파일의 anon_page구조체에 size_t타입의 slot_idx추가 
- 슬롯에 할당되지 않은 상태(swap_out전)에는 특수한 값 (SIZE_MAX)사용
- 
### 기능
- page의 구조체 내 operations필드의 함수 포인터를 anon_ops를 가르키도록 설정
- 아직 swap_out시점 전 이므로 특수한 값(SIZE_MAX)로 설정
- 후에 swap_out시에 할당된 slot_idx에 갱신 필요