### PR TITLE
[TASK] anon_destroy 함수 구현

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -53,6 +53,7 @@
     "stdbool.h": "c",
     "mmu.h": "c",
     "hash.h": "c",
-    "vm.h": "c"
+    "vm.h": "c",
+    "disk.h": "c"
   }
 }

--- a/pintos/include/vm/anon.h
+++ b/pintos/include/vm/anon.h
@@ -1,6 +1,10 @@
 #ifndef VM_ANON_H
 #define VM_ANON_H
-#include "vm/vm.h"
+/* vm.h에서도 anon.h 참조하며 생기는 무한 참조 막기위해 제거
+ * (struct anon_page 정의되기 이전에 vm.h가 참조한다는 뜻)
+ */
+#include <stdbool.h>  // bool
+#include <stddef.h>   // size_t
 struct page;
 enum vm_type;
 

--- a/pintos/vm/anon.c
+++ b/pintos/vm/anon.c
@@ -17,6 +17,9 @@ static void anon_destroy(struct page *page);
 static struct bitmap *swap_table;
 static struct disk *swap_disk;
 
+// 비트 마스킹용 락
+struct lock swap_lock;
+
 /* DO NOT MODIFY this struct */
 static const struct page_operations anon_ops = {
     .swap_in = anon_swap_in,
@@ -24,9 +27,6 @@ static const struct page_operations anon_ops = {
     .destroy = anon_destroy,
     .type = VM_ANON,
 };
-
-// 비트 마스킹용 락
-struct lock swap_lock;
 
 /* 익명 페이지를 위한 데이터를 초기화 합니다. */
 void vm_anon_init(void) {

--- a/pintos/vm/anon.c
+++ b/pintos/vm/anon.c
@@ -1,9 +1,11 @@
 /* anon.c: Implementation of page for non-disk image (a.k.a. anonymous page). */
-#include "devices/anon.h"
+#include "vm/anon.h"
 
 #include "devices/disk.h"
-#include "include/threads/vaddr.h"
 #include "lib/kernel/bitmap.h"
+#include "threads/mmu.h"
+#include "threads/synch.h"
+#include "threads/vaddr.h"
 #include "vm/vm.h"
 
 /* DO NOT MODIFY BELOW LINE */
@@ -23,6 +25,9 @@ static const struct page_operations anon_ops = {
     .type = VM_ANON,
 };
 
+// 비트 마스킹용 락
+struct lock swap_lock;
+
 /* 익명 페이지를 위한 데이터를 초기화 합니다. */
 void vm_anon_init(void) {
   /* swap_disk를 설정하세요 */
@@ -40,7 +45,9 @@ void vm_anon_init(void) {
     return;
   }
 
-  return true;
+  // void라 리턴없고 비트맵 설정 후 락 초기화
+  bitmap_set_all(swap_table, false);
+  lock_init(&swap_lock);
 }
 
 /* anon_page를 초기화 합니다. */
@@ -64,5 +71,25 @@ static bool anon_swap_out(struct page *page) {
 
 /* Destroy the anonymous page. PAGE will be freed by the caller. */
 static void anon_destroy(struct page *page) {
-  struct anon_page *anon_page = &page->anon;
+  struct anon_page *ap = &page->anon;
+
+  /* 1) 스왑 슬롯 해제: 프레임 유무와 무관하게, 슬롯이 있으면 해제 */
+  if (ap->slot_idx != SIZE_MAX) {
+    lock_acquire(&swap_lock);
+    bitmap_reset(swap_table, ap->slot_idx);
+    lock_release(&swap_lock);
+    ap->slot_idx = SIZE_MAX;
+  }
+
+  /* 2) 프레임 반납: 매핑 해제 → 연결 해제 → 프레임 free */
+  if (page->frame != NULL) {
+    struct thread *cur = thread_current();
+    if (pml4_get_page(cur->pml4, page->va) != NULL) {
+      pml4_clear_page(cur->pml4, page->va);
+    }
+
+    page->frame->page = NULL;
+    vm_free_frame(page->frame);
+    page->frame = NULL;
+  }
 }


### PR DESCRIPTION
## 메인 함수

- `anon_destroy`에서 프레임 반납, 스왑 슬롯 해제

- `bit_map_reset`을 통해 디스크 할당 유무 설정하므로 이에 필요한 락 생성

### 수정

- `anon.h`에서 `vm.h`를 참조하며 생기는 문제 해결

- `vm_anon_init`의 타입이 void인데 반환값 존재하는 문제 해결

- `vm_anon_init`에서 swap_table 비트맵 설정, 락 초기화


close: #36 