### PR TITLE
[TASK/37] supplemental_page_table_copy 구현

### DIFF
--- a/pintos/include/vm/vm.h
+++ b/pintos/include/vm/vm.h
@@ -88,7 +88,9 @@ struct page_operations {
 /* Representation of current process's memory space.
  * We don't want to force you to obey any specific design for this struct.
  * All designs up to you for this. */
-struct supplemental_page_table {};
+struct supplemental_page_table {
+  struct hash h;
+};
 
 #include "threads/thread.h"
 void supplemental_page_table_init(struct supplemental_page_table *spt);

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -247,7 +247,78 @@ void supplemental_page_table_init(struct supplemental_page_table *spt UNUSED) {
 
 /* Copy supplemental page table from src to dst */
 bool supplemental_page_table_copy(struct supplemental_page_table *dst UNUSED,
-                                  struct supplemental_page_table *src UNUSED) {}
+                                  struct supplemental_page_table *src UNUSED) {
+  struct hash_iterator iterator;
+  struct page *parent_page;
+  hash_first(&iterator, &src->h);
+  while (hash_next(&iterator)) {
+    parent_page = hash_entry(hash_cur(&iterator), struct page, spt_elem);
+
+    enum vm_type type = parent_page->operations->type;
+    if (type == VM_UNINIT) {
+      type = parent_page->uninit.type;
+    }
+
+    void *upage = pg_round_down(parent_page->va);
+    bool writable = parent_page->writable;
+
+    if (parent_page->operations->type == VM_UNINIT) {
+      vm_initializer *init = parent_page->uninit.init;
+      void *parent_aux = parent_page->uninit.aux;
+      void *child_aux = NULL;
+
+      if (parent_aux) {
+        child_aux = malloc(sizeof(struct load_aux));
+        if (child_aux == NULL) {
+          supplemental_page_table_kill(dst);
+          return false;
+        }
+        memcpy(child_aux, parent_aux, sizeof(struct load_aux));
+
+        struct file *parent_file = ((struct load_aux *)parent_aux)->file;
+        struct file *child_file = file_reopen(parent_file);
+        if (child_file == NULL) {
+          free(child_aux);
+          supplemental_page_table_kill(dst);
+          return false;
+        }
+        ((struct load_aux *)child_aux)->file = child_file;
+      }
+
+      if (!vm_alloc_page_with_initializer(type, upage, writable, init,
+                                          child_aux)) {
+        if (child_aux) {
+          file_close(((struct load_aux *)child_aux)->file);
+          free(child_aux);
+        }
+        supplemental_page_table_kill(dst);
+        return false;
+      }
+    } else {
+      // ANON 또는 FILE 페이지 처리
+      if (!vm_alloc_page(type, upage, writable)) {
+        supplemental_page_table_kill(dst);
+        return false;
+      }
+    }
+    // 부모 페이지가 프레임에 있다면 자식 페이지도 할당받고 내용 복사
+    if (parent_page->frame != NULL) {
+      // 자식 물리프레임 할당 및 매핑
+      if (!vm_claim_page(upage)) {
+        supplemental_page_table_kill(dst);
+        return false;
+      }
+      struct page *child_page = spt_find_page(dst, upage);
+      if (child_page) {
+        memcpy(child_page->frame->kva, parent_page->frame->kva, PGSIZE);
+      } else {
+        supplemental_page_table_kill(dst);
+        return false;
+      }
+    }
+  }
+  return true;
+}
 
 /* Free the resource hold by the supplemental page table */
 void supplemental_page_table_kill(struct supplemental_page_table *spt UNUSED) {


### PR DESCRIPTION
## supplemental_page_table_copy
### 목표
이 함수의 목표는 부모 프로세스의 메모리 구조를 자식 프로세스에게 그대로 복제한다.
fork 시 자식은 부모와 똑같은 코드와 데이터를 가져야 하므로 부모의 spt(src)에 있는 모든 페이지 정보를 자식의 spt(dst)로 복사한다.
### 흐름
1. 부모의 spt 순회
   - `hash_iterator`를 사용하여 부모의 spt(src -> h)에 있는 모든 page 항목을 순회
2. 페이지 정보 추출
   - 순회 중인 `parent_page`로부터 정보 추출
3. 페이지 종류에 따른 분기 처리
   - `parent_page`가 아직 `frame`에 올라오지 않은 `UNINT` 상태인지 `ANON/FILE` 상태인지에 따라 분기
4. UNINIT 페이지 복제
   - `lazy_load_segment`에 필요한 `parent_aux`의 유무 확인
   - `aux` 복사 (원래 얕은 복사로 그냥 `parent_aux` 그대로 사용했는데 그렇게 하지 말라더라고요)
     - 그래서 `malloc` 후 `memcpy`를 통해 `parent_aux`를 그대로 복사
   - `file_reopen` (이것도 원래는 안했는데... 추천 받아서 추가)
     - 부모와 자식이 같은 파일 핸들을 공유하면 `offset`이 꼬이는 문제가 발생한다고 합니다.
     - 이를 위해 `file_reopen`을 사용하여 같은 파일을 가리키지만 독립적인 `offset`을 가지는 child_file을 생성
     - `child_aux -> file`에 덮어씌워 자식이 독립적인으로 파일을 읽을 수 있도록 보장
   - child_page 생성
     - 위에 준비한 모든 정보를 사용하여 `vm_alloc_page_with_initailizer`를 사용하여 자식 spt에 UNINIT 페이지를 삽입
5. 초기화된 페이지(ANON/FILE) 복제
   - `vm_alloc_page` 매크로를 사용
   - 부모와 동일한 타입, 주소, 속성을 가진 페이지만 자식의 spt에 생성
6. frame 복사
   - `parent_page -> frame != NULL` 라면 자식도 그 내용을 복사
   - `vm_claim_page(upage)`를 호출하여 자식 페이지에 새로운 물리 프레임을 할당 후 매핑
   - `spt_find_page`로 자식의 페이지를 찾은 후 부모 frame 데이터를 그대로 복사
7. `struct supplemtal_page_table`에 hash 구조체 없어서 추가했습니다.


close: #37 