### PR TITLE
[FIX] swap-in/out 해결

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -74,6 +74,8 @@
     "system_error": "c",
     "utility": "c",
     "types.h": "c",
-    "page_cache.h": "c"
+    "page_cache.h": "c",
+    "inspect.h": "c",
+    "*.inc": "c"
   }
 }

--- a/pintos/include/vm/file.h
+++ b/pintos/include/vm/file.h
@@ -8,13 +8,6 @@
 
 struct page;
 
-struct mmap_file {
-  struct file *file; /* file_reopen() 한 핸들 (매핑 단위로 1개) */
-  void *base;        /* 매핑 시작 유저 주소 (page-aligned) */
-  size_t length;     /* 요청 길이 (바이트, 마지막 페이지는 일부만 사용 가능) */
-  struct list_elem elem;
-};
-
 struct file_page {
   struct file *file;
   off_t offset;

--- a/pintos/include/vm/file.h
+++ b/pintos/include/vm/file.h
@@ -1,16 +1,26 @@
 #ifndef VM_FILE_H
 #define VM_FILE_H
+#include <stdbool.h>
+
 #include "filesys/file.h"
-#include "vm/vm.h"
+#include "lib/kernel/list.h"
+#include "vm/types.h"
 
 struct page;
-enum vm_type;
+
+struct mmap_file {
+  struct file *file; /* file_reopen() 한 핸들 (매핑 단위로 1개) */
+  void *base;        /* 매핑 시작 유저 주소 (page-aligned) */
+  size_t length;     /* 요청 길이 (바이트, 마지막 페이지는 일부만 사용 가능) */
+  struct list_elem elem;
+};
 
 struct file_page {
   struct file *file;
   off_t offset;
   size_t read_bytes;
   size_t zero_bytes;
+  bool owns_file;
 };
 
 void vm_file_init(void);

--- a/pintos/include/vm/vm.h
+++ b/pintos/include/vm/vm.h
@@ -35,6 +35,7 @@ struct page {
 
   /* Your implementation */
   bool writable;  // 읽기 전용 혹은 읽기/쓰기 가능을 저장하기 위해 추가
+  struct thread *owner;
 
   /* Per-type data are binded into the union.
    * Each function automatically detects the current union */
@@ -52,7 +53,8 @@ struct page {
 struct frame {
   void *kva;
   struct page *page;
-  struct list_elem elem;
+  struct list_elem frame_elem;
+  bool in_table;
 };
 
 /* The function table for page operations.
@@ -101,4 +103,3 @@ bool vm_claim_page(void *va);
 enum vm_type page_get_type(struct page *page);
 
 #endif /* VM_VM_H */
-


### PR DESCRIPTION
수정사항 정리

`file_page` 구조체에 `bool owns_file;` 인자 추가

파일 페이지가 `file_reopen`으로 얻은 핸들 닫게 추적


`fil_backed_initializer`에서 `owns_file = false`로 초기화

`do_mmap`에서 `aux` 설정해주며 `owns_file = true`로 설정

`process.c`의 `lazy_load_segment`에서 `ownds_file = false`로 복제하게 설정
이로 인해 공유핸들 중복 `close` 방지


### `file_backed_destroy` 수정

#### 이전:
`pml4`로 더티면 `file_write_at` 호출 후 `pml4_clear_page` 수행
프레임은 남겨짐

파일 포인터가 있으면 무조건 `file_close` 후 `pml4_clear_page`

#### 이후:
더티비트 확인 동기화 이후 매핑 해제
`frame->page`, `page->frame` 끊음
`vm_free_frame`까지 호출해 프레임 반환

`owns_file` 플래그 확인해 mmap용으로 오픈한 핸들만 닫음
포인터, 플래그 무조건 초기화


### `do_mmap` 수정

#### 이전:
`struct file_page`의 `aux`를 복사함 (단, 소유 정보 X)

#### 이후:
`aux` 생성 시 `owns_file = true`로 설정
실패시 닫아 누수 방지


### `lazy_load_segment` 수정

#### 이전:
실행 파일 세그먼트도 동일하게 복사

#### 이후:
해당 페이지는 실행 파일 핸들을 공유하니
`owns_file = false`로 복사해 중복 `file_close`방지